### PR TITLE
CodeQL_Remediation

### DIFF
--- a/src/ssm_connect/main.py
+++ b/src/ssm_connect/main.py
@@ -92,7 +92,7 @@ def validate_key_permissions(key_path: Path) -> bool:
 
 def find_available_local_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('', 0))
+        s.bind(('127.0.0.1', 0))
         return s.getsockname()[1]
 
 


### PR DESCRIPTION
Fix: Bind socket to localhost instead of all interfaces

Address CodeQL security alert about binding to all network interfaces. While this is a false positive (the socket is immediately closed and never accepts connections), changing to 127.0.0.1 makes the code more explicit about its intent to find local ports only.

This eliminates the CodeQL warning and improves code clarity without any functional changes. The actual port forwarding is performed by AWS SSM Session Manager which binds to localhost by default.

Resolves: CodeQL alert#1